### PR TITLE
.gitignore 에 JetBrains IDE 설정 구성 디렉토리인 .idea 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ yarn-error.log*
 # Misc
 .DS_Store
 *.pem
+
+
+# Jetbrains
+.idea


### PR DESCRIPTION
## 🚀 Summary

JetBrains IDE(IntelliJ, WebStorm 등) 사용 시 생성되는 .idea 디렉토리를 .gitignore에 추가하여 버전 관리에서 제외했습니다.

---

## 🔍 기능 구현 내용

### .gitignore 파일 업데이트

IDE별 설정 파일들이 Git 추적 대상에서 제외되도록 .gitignore 파일을 수정했습니다.

- .idea 디렉토리를 Jetbrains 섹션에 추가
- 개발 환경에 따라 달라질 수 있는 IDE 설정이 저장소에 포함되지 않도록 설정

---

## ✅ 테스트 항목

- [x] .gitignore 파일에 .idea 항목이 정상적으로 추가되었는가?
- [x] 기존 .gitignore 규칙들이 그대로 유지되는가?
- [x] JetBrains IDE 사용 시 .idea 디렉토리가 Git 추적에서 제외되는가?

---

## 💬 고민과 해결 (Optional)

JetBrains IDE를 사용하는 개발자들이 실수로 IDE 설정 파일(.idea 디렉토리)을 커밋하는 것을 방지하기 위해 추가했습니다. 이는 개발 환경 간의 일관성을 유지하고 불필요한 설정 파일들이 저장소에 포함되는 것을 방지합니다.