### PR TITLE
chore: prettier 실행하는 npm 스크립트의 이름을 용도에 따라 :check 와 :fix 로 구분

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "build": "turbo run build",
     "dev": "turbo run dev",
     "lint": "turbo run lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "format:check": "prettier \"**/*.{ts,tsx,md}\"",
+    "format:fix": "prettier --write \"**/*.{ts,tsx,md}\"",
     "check-types": "turbo run check-types"
   },
   "devDependencies": {


### PR DESCRIPTION
## 🚀 Summary

prettier 실행 npm 스크립트의 이름을 용도에 따라 명확하게 구분하여 개발자 경험을 개선했습니다.

---

## 🔍 기능 구현 내용

### prettier 스크립트 명령어 개선

기존의 모호했던 `format` 스크립트를 용도에 따라 두 개로 분리하여 명확성을 높였습니다.

- `format:check`: prettier를 실행하여 포맷팅 상태만 확인 (파일 수정하지 않음)
- `format:fix`: prettier를 실행하여 실제로 파일을 포맷팅

---

## ✅ 테스트 항목

- [x] `pnpm run format:check` 실행 시 파일이 수정되지 않는지 확인
- [x] `pnpm run format:fix` 실행 시 파일이 올바르게 포맷팅되는지 확인
- [x] 기존 `format` 명령어가 제거되었는지 확인

---

## 💬 고민과 해결

혼란을 줄이기 위해 명령어 이름을 직관적으로 변경했습니다:
- `:check`는 검사만 수행 (CI/CD 파이프라인에서 유용)
- `:fix`는 실제 파일 수정 (로컬 개발 시 유용)

이는 eslint의 `--check`와 `--fix` 옵션과 같은 일반적인 린터 도구들의 명명 규칙과 일치합니다.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>