### PR TITLE
build(deps): web 앱에서 의존성이 devDependencies로 잘못 지정된 부분 수정

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,11 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
+    "@repo/common-utils": "workspace:*",
+    "@repo/node-utils": "workspace:*",
+    "@repo/browser-utils": "workspace:*",
+    "@repo/react-utils": "workspace:*",
+    "@repo/react-ui": "workspace:*",
     "next": "^15.4.2",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
@@ -18,11 +23,6 @@
   "devDependencies": {
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
-    "@repo/common-utils": "workspace:*",
-    "@repo/node-utils": "workspace:*",
-    "@repo/browser-utils": "workspace:*",
-    "@repo/react-utils": "workspace:*",
-    "@repo/react-ui": "workspace:*",
     "@types/node": "^22.15.3",
     "@types/react": "19.1.0",
     "@types/react-dom": "19.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,21 @@ importers:
 
   apps/web:
     dependencies:
+      '@repo/browser-utils':
+        specifier: workspace:*
+        version: link:../../packages/browser-utils
+      '@repo/common-utils':
+        specifier: workspace:*
+        version: link:../../packages/common-utils
+      '@repo/node-utils':
+        specifier: workspace:*
+        version: link:../../packages/node-utils
+      '@repo/react-ui':
+        specifier: workspace:*
+        version: link:../../packages/react-ui
+      '@repo/react-utils':
+        specifier: workspace:*
+        version: link:../../packages/react-utils
       next:
         specifier: ^15.4.2
         version: 15.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -73,24 +88,9 @@ importers:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
     devDependencies:
-      '@repo/browser-utils':
-        specifier: workspace:*
-        version: link:../../packages/browser-utils
-      '@repo/common-utils':
-        specifier: workspace:*
-        version: link:../../packages/common-utils
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../configs/eslint-config
-      '@repo/node-utils':
-        specifier: workspace:*
-        version: link:../../packages/node-utils
-      '@repo/react-ui':
-        specifier: workspace:*
-        version: link:../../packages/react-ui
-      '@repo/react-utils':
-        specifier: workspace:*
-        version: link:../../packages/react-utils
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../configs/typescript-config


### PR DESCRIPTION
## 🚀 Summary

web 앱 package.json에서 내부 패키지들이 devDependencies에 잘못 지정되어 있던 문제를 수정했습니다.

---

## 🔍 기능 구현 내용

### 의존성 분류 수정

web 앱에서 런타임에 필요한 내부 패키지들이 devDependencies로 잘못 분류되어 있던 문제를 해결했습니다.

- `@repo/common-utils`: devDependencies → dependencies
- `@repo/node-utils`: devDependencies → dependencies  
- `@repo/browser-utils`: devDependencies → dependencies
- `@repo/react-utils`: devDependencies → dependencies
- `@repo/react-ui`: devDependencies → dependencies

---

## ⚙️ 테스트 환경 셋업

### 1) 의존성 설치

```bash
pnpm install
```

### 2) 개발 서버 실행

```bash
pnpm dev
```

## ✅ 테스트 항목

- [ ] `pnpm dev` 실행 시 정상적으로 개발 서버가 시작되는가?
- [ ] web 앱에서 내부 패키지들을 정상적으로 import할 수 있는가?
- [ ] production 빌드 시 dependencies가 올바르게 번들링되는가?

---

## 💬 고민과 해결

이 문제는 monorepo 환경에서 내부 패키지들의 의존성을 올바르게 분류하는 것의 중요성을 보여줍니다. 
런타임에 필요한 패키지들은 dependencies에, 빌드 타임에만 필요한 도구들은 devDependencies에 위치해야 합니다.